### PR TITLE
[#3] Implement functions to convert from Memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,7 @@ matrix:
   - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.3
-  
-  - ghc: 8.2.2
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.2.2.yaml"
-  
-  - ghc: 8.4.4
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.4.4.yaml"
-  
+
   - ghc: 8.6.3
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
@@ -47,7 +41,7 @@ script:
     fi
 
   # HLint check
-  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .
+  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -XTypeApplications .
 
 notifications:
   email: false

--- a/src/Membrain.hs
+++ b/src/Membrain.hs
@@ -1,6 +1,7 @@
+-- | Type-safe memory units.
+
 module Membrain
-       ( someFunc
+       ( module Membrain.Memory
        ) where
 
-someFunc :: IO ()
-someFunc = putStrLn ("someFunc" :: String)
+import Membrain.Memory

--- a/src/Membrain/Memory.hs
+++ b/src/Membrain/Memory.hs
@@ -9,10 +9,13 @@ module Membrain.Memory
        , toMemory
 
          -- * Conversion functions
-       , memToBits
-       , memToRat
-       , memFloor
+       , toBits
+       , toRat
+       , floor
        ) where
+
+import Prelude hiding (floor)
+import qualified Prelude
 
 import Data.Coerce (coerce)
 import Data.Kind (Type)
@@ -38,14 +41,14 @@ toMemory = coerce
 
 {- | Lossless 'Memory' conversion to bits. Alias to 'unMemory'.
 -}
-memToBits :: Memory mem -> Natural
-memToBits = coerce
-{-# INLINE memToBits #-}
+toBits :: Memory mem -> Natural
+toBits = coerce
+{-# INLINE toBits #-}
 
 -- | Lossless 'Memory' conversion to rational number.
-memToRat :: forall (mem :: Nat) . KnownNat mem => Memory mem -> Ratio Natural
-memToRat (Memory m) = m % natVal (Proxy @mem)
-{-# INLINE memToRat #-}
+toRat :: forall (mem :: Nat) . KnownNat mem => Memory mem -> Ratio Natural
+toRat (Memory m) = m % natVal (Proxy @mem)
+{-# INLINE toRat #-}
 
 {- | Floor 'Memory' unit to integral number. This function may lose some
 information, so use only when:
@@ -53,14 +56,14 @@ information, so use only when:
 1. You don't care about losing information.
 2. You are sure that there will be no loss.
 -}
-memFloor
+floor
     :: forall (n :: Type) (mem :: Nat) .
        (Integral n, KnownNat mem)
     => Memory mem
     -> n
-memFloor = floor . memToRat
-{-# INLINE memFloor #-}
-{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Int     #-}
-{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Word    #-}
-{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Integer #-}
-{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Natural #-}
+floor = Prelude.floor . toRat
+{-# INLINE floor #-}
+{-# SPECIALIZE floor :: KnownNat mem => Memory mem -> Int     #-}
+{-# SPECIALIZE floor :: KnownNat mem => Memory mem -> Word    #-}
+{-# SPECIALIZE floor :: KnownNat mem => Memory mem -> Integer #-}
+{-# SPECIALIZE floor :: KnownNat mem => Memory mem -> Natural #-}

--- a/src/Membrain/Memory.hs
+++ b/src/Membrain/Memory.hs
@@ -1,12 +1,24 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds  #-}
+{-# LANGUAGE TypeInType #-}
 
 -- | This module contains 'Memory' data type.
 
 module Membrain.Memory
-       ( Memory (..)
+       ( -- * Data type
+         Memory (..)
+       , toMemory
+
+         -- * Conversion functions
+       , memToBits
+       , memToRat
+       , memFloor
        ) where
 
-import GHC.TypeNats (Nat)
+import Data.Coerce (coerce)
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
+import Data.Ratio (Ratio, (%))
+import GHC.TypeNats (KnownNat, Nat, natVal)
 import Numeric.Natural (Natural)
 
 
@@ -16,3 +28,39 @@ is type level representation of the unit.
 newtype Memory (mem :: Nat) = Memory
     { unMemory :: Natural
     } deriving (Show, Eq)
+
+{- | Convert memory from one unit to another. __Note:__ this changes only view,
+not model. So this operation has zero runtime cost.
+-}
+toMemory :: forall (to :: Nat) (from :: Nat) . Memory from -> Memory to
+toMemory = coerce
+{-# INLINE toMemory #-}
+
+{- | Lossless 'Memory' conversion to bits. Alias to 'unMemory'.
+-}
+memToBits :: Memory mem -> Natural
+memToBits = coerce
+{-# INLINE memToBits #-}
+
+-- | Lossless 'Memory' conversion to rational number.
+memToRat :: forall (mem :: Nat) . KnownNat mem => Memory mem -> Ratio Natural
+memToRat (Memory m) = m % natVal (Proxy @mem)
+{-# INLINE memToRat #-}
+
+{- | Floor 'Memory' unit to integral number. This function may lose some
+information, so use only when:
+
+1. You don't care about losing information.
+2. You are sure that there will be no loss.
+-}
+memFloor
+    :: forall (n :: Type) (mem :: Nat) .
+       (Integral n, KnownNat mem)
+    => Memory mem
+    -> n
+memFloor = floor . memToRat
+{-# INLINE memFloor #-}
+{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Int     #-}
+{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Word    #-}
+{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Integer #-}
+{-# SPECIALIZE memFloor :: KnownNat mem => Memory mem -> Natural #-}


### PR DESCRIPTION
Resolves #3 

I'm not sure about naming... We need to decide, whether we want to aim for `qualified` imports or explicit import lists. In case of qualified imports users will use library in one the following way (though, we can recommend one):

```haskell
import qualified Membrain -- as Membrain
import qualified Membrain as Memory
import qualified Membrain as Mem
```

If we aim for qualified imports, we can remove `mem` prefix from conversion functions. So instead of `memToRat` it will be `Mem.toRat`. But at this point we need to think how many operators are we going to have :telephone_receiver: 

If we don't aim for qualified imports, then alternatively to `mem` prefix we can consider using more verbose and clear `memory` prefix. With qualified imports users have flexibility (they can have `Membrain.toRat` or `Memory.toRat` or `Mem.toRat` but that's not always good, though also not always bad).

What do you think?