### PR TITLE
Fix NoStartIsType error for hlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 script:
   # HLint check
-  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -XTypeApplications .
+  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -XTypeApplications -XNoStarIsType .
   - |
     if [ -z "$STACK_YAML" ]; then
        cabal new-test


### PR DESCRIPTION
New `hlint` started to fail. I hope that this fixes it on CI.