### PR TITLE
[#27] Introduce Terminating constraint for preventing hanging showMemory

### DIFF
--- a/membrain.cabal
+++ b/membrain.cabal
@@ -48,6 +48,7 @@ common common-options
                        -Widentities
                        -Wredundant-constraints
                        -fhide-source-paths
+                       -freduction-depth=500
                        -Wmissing-export-lists
                        -Wpartial-fields
   if impl(ghc >= 8.8.1)

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -48,7 +48,6 @@ common common-options
                        -Widentities
                        -Wredundant-constraints
                        -fhide-source-paths
-                       -freduction-depth=0
                        -Wmissing-export-lists
                        -Wpartial-fields
   if impl(ghc >= 8.8.1)
@@ -77,6 +76,8 @@ library
                          Membrain.Constructors
                          Membrain.Memory
                          Membrain.Units
+  ghc-options:
+                       -freduction-depth=0
 
 test-suite membrain-test
   import:              common-options

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -50,6 +50,7 @@ common common-options
                        -fhide-source-paths
                        -Wmissing-export-lists
                        -Wpartial-fields
+                       -freduction-depth=0
   if impl(ghc >= 8.8.1)
     ghc-options:       -Wmissing-deriving-strategies
                        -Werror=missing-deriving-strategies

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -94,6 +94,7 @@ test-suite membrain-test
                      , type-spec ^>= 0.4.0.0
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+                       -freduction-depth=0
 
 test-suite doctest
   import:              common-options
@@ -105,3 +106,4 @@ test-suite doctest
                      , Glob
 
   ghc-options:         -threaded
+                       -freduction-depth=0

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -50,7 +50,7 @@ common common-options
                        -fhide-source-paths
                        -Wmissing-export-lists
                        -Wpartial-fields
-                       -freduction-depth=0
+                       -freduction-depth=250
   if impl(ghc >= 8.8.1)
     ghc-options:       -Wmissing-deriving-strategies
                        -Werror=missing-deriving-strategies

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -48,7 +48,7 @@ common common-options
                        -Widentities
                        -Wredundant-constraints
                        -fhide-source-paths
-                       -freduction-depth=500
+                       -freduction-depth=0
                        -Wmissing-export-lists
                        -Wpartial-fields
   if impl(ghc >= 8.8.1)

--- a/membrain.cabal
+++ b/membrain.cabal
@@ -76,8 +76,6 @@ library
                          Membrain.Constructors
                          Membrain.Memory
                          Membrain.Units
-  ghc-options:
-                       -freduction-depth=0
 
 test-suite membrain-test
   import:              common-options
@@ -94,7 +92,6 @@ test-suite membrain-test
                      , type-spec ^>= 0.4.0.0
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-                       -freduction-depth=0
 
 test-suite doctest
   import:              common-options
@@ -106,4 +103,3 @@ test-suite doctest
                      , Glob
 
   ghc-options:         -threaded
-                       -freduction-depth=0

--- a/src/Membrain/Memory.hs
+++ b/src/Membrain/Memory.hs
@@ -111,9 +111,9 @@ instance Monoid (Memory (mem :: Nat)) where
     {-# INLINE mconcat #-}
 
 #if ( __GLASGOW_HASKELL__ >= 804 )
-type IsMemory mem = (KnownNat mem, KnownUnitSymbol mem, Terminating mem)
+type KnownMem mem = (KnownNat mem, KnownUnitSymbol mem, Terminating mem)
 #else
-type IsMemory mem = (KnownNat mem, KnownUnitSymbol mem)
+type KnownMem mem = (KnownNat mem, KnownUnitSymbol mem)
 #endif
 
 {- |
@@ -131,7 +131,7 @@ different forms of units then the 'show' function for 'Memory' hangs.
 >>> showMemory (Memory 22 :: Memory Byte)
 "2.75B"
 -}
-showMemory :: forall mem . (IsMemory mem) => Memory mem -> String
+showMemory :: forall mem . (KnownMem mem) => Memory mem -> String
 showMemory (Memory m) = showFrac m (nat @mem) ++ unitSymbol @mem
   where
     showFrac :: Natural -> Natural -> String
@@ -320,7 +320,7 @@ collections, or when 'Memory' of non-specified unit can be returned.
 
 -- | Existential data type for 'Memory's.
 data AnyMemory
-    = forall (mem :: Nat) . (IsMemory mem)
+    = forall (mem :: Nat) . (KnownMem mem)
     => MkAnyMemory (Memory mem)
 
 instance Show AnyMemory where

--- a/src/Membrain/Memory.hs
+++ b/src/Membrain/Memory.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE AllowAmbiguousTypes       #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE DerivingStrategies        #-}
@@ -54,7 +55,7 @@ import GHC.Generics (Generic)
 import GHC.TypeNats (KnownNat, Nat, natVal')
 import Numeric.Natural (Natural)
 
-import Membrain.Units (KnownUnitSymbol, unitSymbol)
+import Membrain.Units (KnownUnitSymbol, Terminating, unitSymbol)
 
 import qualified Prelude
 
@@ -119,7 +120,7 @@ different forms of units then the 'show' function for 'Memory' hangs.
 >>> showMemory (Memory 22 :: Memory Byte)
 "2.75B"
 -}
-showMemory :: forall mem . (KnownNat mem, KnownUnitSymbol mem) => Memory mem -> String
+showMemory :: forall mem . (KnownNat mem, KnownUnitSymbol mem, Terminating mem) => Memory mem -> String
 showMemory (Memory m) = showFrac m (nat @mem) ++ unitSymbol @mem
   where
     showFrac :: Natural -> Natural -> String
@@ -308,7 +309,7 @@ collections, or when 'Memory' of non-specified unit can be returned.
 
 -- | Existential data type for 'Memory's.
 data AnyMemory
-    = forall (mem :: Nat) . (KnownNat mem, KnownUnitSymbol mem)
+    = forall (mem :: Nat) . (KnownNat mem, KnownUnitSymbol mem, Terminating mem)
     => MkAnyMemory (Memory mem)
 
 instance Show AnyMemory where

--- a/src/Membrain/Units.hs
+++ b/src/Membrain/Units.hs
@@ -183,7 +183,8 @@ type family Terminating2 (original :: Nat) (mod_result :: Nat) (val :: Nat) :: C
   Terminating2 original _ mul =
     TypeError ('Text "Value "
          ':<>: 'ShowType original
-         ':<>: 'Text " should be a terminating decimal with only multipliers being 2 and 5"
+         ':<>: 'Text " should only multipliers of 2 and 5"
          ':<>: 'Text " (ie. should be in form 2^x.5^y)"
-         ':$$: 'Text "but it has the multiplier " ':<>: 'ShowType mul)
+         ':$$: 'Text "but it has the multiplier " ':<>: 'ShowType mul
+         ':$$: 'Text "See showMemory function for why this is needed.")
 #endif

--- a/src/Membrain/Units.hs
+++ b/src/Membrain/Units.hs
@@ -60,14 +60,19 @@ module Membrain.Units
        , KnownUnitSymbol
        , unitSymbol
 
+#if ( __GLASGOW_HASKELL__ >= 804 )
          -- * Type family for unit safety
        , Terminating
+#endif
        ) where
 
 import Data.Kind (Constraint)
 import GHC.Exts (Proxy#, proxy#)
 import GHC.TypeLits (ErrorMessage (..), KnownSymbol, Symbol, TypeError, symbolVal')
-import GHC.TypeNats (type (*), Div, Mod, Nat)
+import GHC.TypeNats (type (*), Nat)
+#if ( __GLASGOW_HASKELL__ >= 804 )
+import GHC.TypeNats (Div, Mod)
+#endif
 
 
 type Bit       = 1
@@ -146,6 +151,7 @@ unitSymbol :: forall (mem :: Nat) . KnownUnitSymbol mem => String
 unitSymbol = symbolVal' (proxy# :: Proxy# (UnitSymbol mem))
 {-# INLINE unitSymbol #-}
 
+#if ( __GLASGOW_HASKELL__ >= 804 )
 -- | Decides whether given decimal is a terminating decimal or not.
 type family Terminating (val :: Nat) :: Constraint where
   Terminating v = TerminatingOrig v v
@@ -166,3 +172,4 @@ type family Terminating2 (original :: Nat) (mod_result :: Nat) (val :: Nat) :: C
          ':<>: 'Text " should be a terminating decimal with only factors 2 and 5"
          ':<>: 'Text " (ie. should be in form 2^x.5^y)"
          ':$$: 'Text "but it has factor " ':<>: 'ShowType factor)
+#endif

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -16,4 +16,5 @@ main = do
         : "-XDerivingStrategies"
         : "-XGeneralizedNewtypeDeriving"
         : "-XDeriveGeneric"
+        : "-freduction-depth=0"
         : sourceFiles

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -16,5 +16,5 @@ main = do
         : "-XDerivingStrategies"
         : "-XGeneralizedNewtypeDeriving"
         : "-XDeriveGeneric"
-        : "-freduction-depth=0"
+        : "-freduction-depth=250"
         : sourceFiles


### PR DESCRIPTION
Resolves #27 

Factorizes and validates input to `showMemory` at compile time, eliminating risk for a hanging `showMemory` call.
 
### :white_check_mark: Check list
- [X] New/fixed features work as expected (Bonus points for the new tests).
- [X] There are no warnings during compilation.
- [X] `hlint .` output is: _No Hints_ (there are 4, none of which was caused by this PR).
- [X] The code is formatted with the [`stylish-haskell`][stylish-tool] tool 
      using [stylish-haskell.yaml][stylish] file in the repository.
- [X] The code style of the files you changed is preserved (for more specific 
      details on our style guide check [this document][style-guide]).
- [X] Commit messages are in the proper format.
      Start the first line of the commit with the issue number in square parentheses.

Demonstraition in ghci:

```shell
> :set -XDataKinds
> :set -XTypeFamilies
> type instance UnitSymbol 3000 = "invalid1"
> type instance UnitSymbol 7000 = "invalid2"

> showMemory (toMemory @3000 $ bit 4)
<interactive>:5:1: error:
    • Value 3000 should be a terminating decimal with only factors 2 and 5 (ie. should be in form 2^x.5^y)
      but it has factor 3
    • In the expression: showMemory (toMemory @3000 $ bit 4)
      In an equation for ‘it’: it = showMemory (toMemory @3000 $ bit 4)

> showMemory (toMemory @7000 $ bit 4)
<interactive>:6:1: error:
    • Value 7000 should be a terminating decimal with only factors 2 and 5 (ie. should be in form 2^x.5^y)
      but it has factor 7
    • In the expression: showMemory (toMemory @7000 $ bit 4)
      In an equation for ‘it’: it = showMemory (toMemory @7000 $ bit 4)

> showMemory (toMemory @8192 $ bit 4)
"0.00048828125KiB"
```